### PR TITLE
fix: Исправлена загрузка изображений

### DIFF
--- a/src/images/imagesController.ts
+++ b/src/images/imagesController.ts
@@ -81,7 +81,8 @@ export class ImagesController {
                 if (images.length == 0) {
                     await fsPromise.mkdir(path.join('public', ImagesController.localizePath(imagePath)), {recursive: true});
                     imagePath += '0.' + extension;
-                    await fsPromise.rename(tempFile, path.join('public', ImagesController.localizePath(imagePath)));
+                    await fsPromise.copyFile(tempFile, path.join('public', ImagesController.localizePath(imagePath)));
+                    await fsPromise.rm(tempFile);
                     img = new Image();
                     img.blob = imagePath;
                     await imageRepo.save(img);


### PR DESCRIPTION
Исправлено исключение, вызываемое rename'ом при загрузке файлов, когда директория временных файлов и директория userimages находятся на разных разделах.